### PR TITLE
removed alpaca_derive from dockerfile

### DIFF
--- a/pipeline/alpaca/dockerfile
+++ b/pipeline/alpaca/dockerfile
@@ -7,7 +7,6 @@ RUN pip install -r ${LAMBDA_TASK_ROOT}/requirements.txt
 COPY run_pipeline.py ${LAMBDA_TASK_ROOT}/
 COPY alpaca_extract.py ${LAMBDA_TASK_ROOT}/
 COPY alpaca_transform_cleaning.py ${LAMBDA_TASK_ROOT}/
-COPY alpaca_transform_derive.py ${LAMBDA_TASK_ROOT}/
 COPY alpaca_load.py ${LAMBDA_TASK_ROOT}/
 COPY top_100_tech_companies.py ${LAMBDA_TASK_ROOT}/
 COPY logger.py ${LAMBDA_TASK_ROOT}/


### PR DESCRIPTION
This pull request makes a minor change to the Docker build process by removing the copy step for a specific file. The change ensures that `alpaca_transform_derive.py` is no longer included in the Docker image.

- Dockerfile update:
  * Removed the line that copies `alpaca_transform_derive.py` into the Lambda task root, so this file will not be available in the built image.